### PR TITLE
Fix Largest Resolution option

### DIFF
--- a/ydl.ahk
+++ b/ydl.ahk
@@ -82,7 +82,11 @@ Download(){
 
 	reverseSort := Sign==">=" || Res="smallest"
 	resolution 	:= isInteger(Res)? ":" Res :""
-	format 		:= "-S """ (reverseSort?"+":"") "res" resolution """"
+	; yt-dlp defaults to largest video if option blank
+	If (Res = "largest")
+		format          := ""
+	else
+		format 		:= "-S """ (reverseSort?"+":"") "res" resolution """"
 	homePath	:= "-P ""home:" Path """"
 	update 		:= Upd? "-U" :""
 


### PR DESCRIPTION
When choosing **Largest** for the resolution in the GUI, it would instead find and download the **smallest**.
Added a quick check to use yt-dlp's default action (find best video) when **Largest** option set so it acts as intended.